### PR TITLE
Allow redeploying a PR build

### DIFF
--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -56,9 +56,13 @@ jobs:
         run: |
           echo 'PACKAGE_VERSION='${PACKAGE_VERSION_ORIG}-pr.${PR_NUMBER} >> $GITHUB_ENV
 
-      - name: Preflight Check Version
+      - name: Preflight Check Version - App
         run: |
-          npx microapps-publish preflight -a ${APP_NANE} -n ${PACKAGE_VERSION} -d ${DEPLOYER_LAMBDA_NAME}
+          npx microapps-publish preflight -a ${APP_NANE} -n ${PACKAGE_VERSION} -d ${DEPLOYER_LAMBDA_NAME} --overwrite
+
+      - name: Preflight Check Version - Story Book
+        run: |
+          npx microapps-publish preflight -a ${APP_NANE}-storybook -n ${PACKAGE_VERSION} -d ${DEPLOYER_LAMBDA_NAME} --overwrite
 
       - name: Apply NPM Version
         run: |
@@ -82,7 +86,7 @@ jobs:
 
       - name: Publish Story Book to MicroApps
         run: |
-          npx microapps-publish publish-static -a ${APP_NANE}-storybook -n ${PACKAGE_VERSION} -d ${DEPLOYER_LAMBDA_NAME} -s storybook-static -i index.html
+          npx microapps-publish publish-static -a ${APP_NANE}-storybook -n ${PACKAGE_VERSION} -d ${DEPLOYER_LAMBDA_NAME} -s storybook-static -i index.html --overwrite --noCache
 
       - name: Smoke Check CDK
         run: npx cdk list
@@ -92,4 +96,4 @@ jobs:
 
       - name: Publish App to MicroApps
         run: |
-          npx microapps-publish publish -a ${APP_NANE} -n ${PACKAGE_VERSION} -d ${DEPLOYER_LAMBDA_NAME} -l microapps-app-${APP_NANE}-${ENV}-pr-${PR_NUMBER}
+          npx microapps-publish publish -a ${APP_NANE} -n ${PACKAGE_VERSION} -d ${DEPLOYER_LAMBDA_NAME} -l microapps-app-${APP_NANE}-${ENV}-pr-${PR_NUMBER} -s .serverless_nextjs/assets/release/${PACKAGE_VERSION} --overwrite --noCache

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-dynamodb": "^3.19.0",
         "@aws-sdk/lib-dynamodb": "^3.19.0",
         "@carbon/themes": "^10.30.0",
-        "@pwrdrvr/microapps-datalib": "^0.0.24",
+        "@pwrdrvr/microapps-datalib": "^0.0.25",
         "@pwrdrvr/serverless-nextjs-router": "^0.0.2",
         "@reduxjs/toolkit": "^1.5.1",
         "carbon-components": "^10.31.0",
@@ -38,7 +38,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.13.10",
-        "@pwrdrvr/microapps-publish": "^0.0.24",
+        "@pwrdrvr/microapps-publish": "^0.0.26",
         "@sls-next/serverless-component": "^1.19.0",
         "@storybook/addon-actions": "^6.2.8",
         "@storybook/addon-essentials": "^6.2.8",
@@ -6516,9 +6516,9 @@
       "dev": true
     },
     "node_modules/@pwrdrvr/microapps-datalib": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@pwrdrvr/microapps-datalib/-/microapps-datalib-0.0.24.tgz",
-      "integrity": "sha512-J5jwzMMCFwUDjk3YYipy1dufxBWCD3Pb4zy2FBFaXQGnFvaHQEgeZ7Dgmv6aXhwPlpGpsQZ2XhAfUuJf5p9gHw==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@pwrdrvr/microapps-datalib/-/microapps-datalib-0.0.25.tgz",
+      "integrity": "sha512-jW+YH4RKB7BFgoU2W3z0QL38Vk0REB14lt6yWV++wIvH0Wl70A6cavdnBPKfqy40n1shLFosW4740ZEWS7kVBg==",
       "dependencies": {
         "class-transformer": "^0.4.0"
       },
@@ -6529,9 +6529,9 @@
       }
     },
     "node_modules/@pwrdrvr/microapps-publish": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@pwrdrvr/microapps-publish/-/microapps-publish-0.0.24.tgz",
-      "integrity": "sha512-InJv2fCbawDmIL/weUjEsqwkRsACE+ReWZRynWmSToJKXJ9kFQZ+7K/LDp3K9sapSs46Wh6YLEfVb1gSDpus8Q==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@pwrdrvr/microapps-publish/-/microapps-publish-0.0.26.tgz",
+      "integrity": "sha512-LQpYgChBsCorU68hQQMODh3fak2+tX45s7Po+g4GIeSnnmXuP167+IMuf+EHVRdGXn5AfIjbfEW6NFPPPC/TgQ==",
       "dev": true,
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.20.0",
@@ -41539,17 +41539,17 @@
       "dev": true
     },
     "@pwrdrvr/microapps-datalib": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@pwrdrvr/microapps-datalib/-/microapps-datalib-0.0.24.tgz",
-      "integrity": "sha512-J5jwzMMCFwUDjk3YYipy1dufxBWCD3Pb4zy2FBFaXQGnFvaHQEgeZ7Dgmv6aXhwPlpGpsQZ2XhAfUuJf5p9gHw==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@pwrdrvr/microapps-datalib/-/microapps-datalib-0.0.25.tgz",
+      "integrity": "sha512-jW+YH4RKB7BFgoU2W3z0QL38Vk0REB14lt6yWV++wIvH0Wl70A6cavdnBPKfqy40n1shLFosW4740ZEWS7kVBg==",
       "requires": {
         "class-transformer": "^0.4.0"
       }
     },
     "@pwrdrvr/microapps-publish": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@pwrdrvr/microapps-publish/-/microapps-publish-0.0.24.tgz",
-      "integrity": "sha512-InJv2fCbawDmIL/weUjEsqwkRsACE+ReWZRynWmSToJKXJ9kFQZ+7K/LDp3K9sapSs46Wh6YLEfVb1gSDpus8Q==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@pwrdrvr/microapps-publish/-/microapps-publish-0.0.26.tgz",
+      "integrity": "sha512-LQpYgChBsCorU68hQQMODh3fak2+tX45s7Po+g4GIeSnnmXuP167+IMuf+EHVRdGXn5AfIjbfEW6NFPPPC/TgQ==",
       "dev": true,
       "requires": {
         "@aws-sdk/client-lambda": "^3.20.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@aws-sdk/client-dynamodb": "^3.19.0",
     "@aws-sdk/lib-dynamodb": "^3.19.0",
     "@carbon/themes": "^10.30.0",
-    "@pwrdrvr/microapps-datalib": "^0.0.24",
+    "@pwrdrvr/microapps-datalib": "^0.0.25",
     "@pwrdrvr/serverless-nextjs-router": "^0.0.2",
     "@reduxjs/toolkit": "^1.5.1",
     "carbon-components": "^10.31.0",
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",
-    "@pwrdrvr/microapps-publish": "^0.0.24",
+    "@pwrdrvr/microapps-publish": "^0.0.26",
     "@sls-next/serverless-component": "^1.19.0",
     "@storybook/addon-actions": "^6.2.8",
     "@storybook/addon-essentials": "^6.2.8",


### PR DESCRIPTION
- Update `microapps-publish` version to a version that supports overwriting an existing app deploy and disabling long-term caching on CloudFront
- Modify the PR workflow to pass the `--overwrite` and  `--noCache` flags