### PR TITLE
fix: repair main branch build and deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Cache Node Modules
         id: cache-node-modules
@@ -92,7 +92,7 @@ jobs:
         working-directory: packages/app/
         run: zip -r storybook-static.zip storybook-static
       - name: Upload Zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: storybook_zip
           path: packages/app/storybook-static.zip
@@ -117,10 +117,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Cache Node Modules
         id: cache-node-modules
@@ -136,7 +136,7 @@ jobs:
         run: npm ci
 
       - name: Download Artifact - Story Book
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: storybook_zip
           path: packages/app/
@@ -146,7 +146,7 @@ jobs:
         run: unzip storybook-static.zip
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-session-name: microapps-app-${{ env.APP_NAME }}-build
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/builder-writeRole
@@ -201,10 +201,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Cache Node Modules
         id: cache-node-modules
@@ -241,7 +241,7 @@ jobs:
         run: npm run build
 
       - name: Download Artifact - App
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: app_zip
           path: packages/cdk-construct/lib/
@@ -251,7 +251,7 @@ jobs:
         run: unzip -o nextjs.zip
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-session-name: microapps-app-${{ env.APP_NAME }}-build
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/builder-writeRole

--- a/.github/workflows/r_build-app.yml
+++ b/.github/workflows/r_build-app.yml
@@ -31,10 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Cache Node Modules
         id: cache-node-modules
@@ -137,7 +137,7 @@ jobs:
         run: |
           npm pack
       - name: Upload NPM tarball
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk_npm_package
           path: packages/cdk-construct/pwrdrvr-microapps-app-${{ env.APP_NAME }}-cdk-${{ inputs.packageVersion }}.tgz
@@ -147,7 +147,7 @@ jobs:
         working-directory: packages/cdk-construct/lib/
         run: zip -r nextjs.zip microapps-app-${APP_NAME}
       - name: Upload Zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app_zip
           path: packages/cdk-construct/lib/nextjs.zip

--- a/.github/workflows/r_version.yml
+++ b/.github/workflows/r_version.yml
@@ -40,10 +40,10 @@ jobs:
             echo "PR_SUFFIX=" >> $GITHUB_ENV
           fi
 
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Cache Node Modules
         id: cache-node-modules
@@ -87,7 +87,7 @@ jobs:
         run: echo ${PACKAGE_VERSION} > version.txt
 
       - name: Upload version.txt
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: version-txt
           path: version.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Set git identity
         run: |-
@@ -101,7 +101,7 @@ jobs:
       # gets OOM killed at 2 GB of RAM usage for some reason.
       #
       - name: Download Artifact - App
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: app_zip
           path: packages/cdk-construct/lib/
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload CDK Construct Artifact
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdk-construct-dist
           path: packages/cdk-construct/dist
@@ -164,13 +164,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Use Node.js 16
-        uses: actions/setup-node@v3
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Download CDK Construct build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cdk-construct-dist
           path: packages/cdk-construct/dist

--- a/packages/cdk-construct/src/index.ts
+++ b/packages/cdk-construct/src/index.ts
@@ -2,7 +2,6 @@ import { existsSync } from 'fs';
 import { Aws, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
-import * as logs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import * as path from 'path';
 
@@ -88,7 +87,9 @@ export class MicroAppsAppRelease extends Construct implements IMicroAppsAppRelea
     //
     this._lambdaFunction = new lambda.Function(this, 'app-lambda', {
       code,
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: new lambda.Runtime('nodejs20.x', lambda.RuntimeFamily.NODEJS, {
+        supportsInlineCode: true,
+      }),
       handler: 'run.sh',
       functionName,
       environment: {
@@ -103,7 +104,6 @@ export class MicroAppsAppRelease extends Construct implements IMicroAppsAppRelea
         PORT: '3000',
         READINESS_CHECK_PATH: '/release',
       },
-      logRetention: logs.RetentionDays.ONE_MONTH,
       memorySize: 1769,
       timeout: Duration.seconds(15),
       description: process.env.npm_package_version || '',


### PR DESCRIPTION
## Summary

I repaired the active main-branch build and deploy bustage in the release app workflows and CDK construct.

I upgraded the deprecated artifact actions, moved the active CI/release workflow paths to Node 20, updated the AWS credentials action in the deploy path, and stopped synthesizing the deprecated log-retention helper Lambda runtime during deploy.

## What I changed

- I upgraded `actions/upload-artifact` and `actions/download-artifact` from `v3` to `v4` in the active CI and release workflows.
- I moved the active build and deploy workflow steps from `actions/setup-node@v3` on Node 16 to `actions/setup-node@v4` on Node 20.
- I updated the active deploy workflow paths to `aws-actions/configure-aws-credentials@v4`.
- I changed the release app Lambda runtime to `nodejs20.x` and removed the `logRetention` setting so CDK stops creating the deprecated Node.js 14 log-retention helper Lambda.

## Verification

I verified locally with:

- isolated `packages/app` CI-style `npm ci`
- workflow YAML parsing for the changed workflow files
- `npm run lint` (existing warnings only)

A plain local `npm run build` still hits the repo's existing TypeScript/lib-check issue in `flatpickr` and `carbon-components-react` unless the workflow's `tsconfig` patch step is applied, which matches the existing CI workaround in this repo.
