### PR TITLE
Tighten beta release validation

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -37,6 +37,12 @@ Use the bundled planner to gather release facts and raw note inputs:
 python3 .agents/skills/release/scripts/release_plan.py --output-dir .local/release
 ```
 
+If the user wants a beta or other prerelease, ask the planner for a prerelease suggestion too:
+
+```bash
+python3 .agents/skills/release/scripts/release_plan.py --output-dir .local/release --prerelease-channel beta
+```
+
 It writes:
 
 - `.local/release/release-plan.json`
@@ -51,7 +57,7 @@ The planner:
 - groups PR-backed changes separately from direct commits on `main`
 - captures contributor mentions for PR-backed items
 
-The planner suggests the next stable tag. If the user wants a beta release, use that stable target as the base and convert it to `<stable-tag>-beta.N`.
+The planner suggests the next stable tag. If the user wants a beta release, rerun it with `--prerelease-channel beta` so it also suggests the next `<stable-tag>-beta.N`.
 
 ## Approval Prompt
 
@@ -98,7 +104,7 @@ Use the planner's suggestion unless the user overrides it.
 - Do not jump from `v0.9.0` to `v1.0.0` unless the user explicitly asks.
 - For a beta release, start from the planner's suggested stable target and use `-beta.N`.
 - If there is no existing beta for that target, start at `-beta.1`.
-- If betas already exist for that target, increment the highest existing beta number before creating the GitHub prerelease.
+- If betas already exist for that target, use the planner's prerelease suggestion so you increment the highest existing beta number before creating the GitHub prerelease.
 
 The bundled planner treats a patch release as the default only when all of these are true:
 
@@ -121,6 +127,8 @@ python3 .agents/skills/release/scripts/release_plan.py --output-dir .local/relea
 ```
 
 2. Read `.local/release/release-plan.md` and summarize the proposed release for approval.
+
+If this is a prerelease, run the planner with `--prerelease-channel beta` before summarizing so the approval prompt includes the exact prerelease tag.
 
 3. After approval, write:
 

--- a/.agents/skills/release/scripts/release_plan.py
+++ b/.agents/skills/release/scripts/release_plan.py
@@ -16,6 +16,7 @@ from typing import Any
 
 
 SEMVER_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+PRERELEASE_TAG_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)-(?P<channel>[A-Za-z][0-9A-Za-z-]*)\.(?P<number>\d+)$")
 CONVENTIONAL_RE = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]+\))?(?P<breaking>!)?: (?P<summary>.+)$")
 TRAILING_PR_RE = re.compile(r"\s+\(#\d+\)$")
 HOUSEKEEPING_SUBJECT_RES = (
@@ -78,6 +79,10 @@ def parse_args() -> argparse.Namespace:
         default=".local/release",
         help="Directory for release-plan.json and release-plan.md (default: .local/release)",
     )
+    parser.add_argument(
+        "--prerelease-channel",
+        help="Optional prerelease channel to suggest from the stable target, for example beta",
+    )
     return parser.parse_args()
 
 
@@ -101,6 +106,33 @@ def parse_semver(tag: str) -> tuple[int, int, int]:
 def format_tag(parts: tuple[int, int, int]) -> str:
     major, minor, patch = parts
     return f"v{major}.{minor}.{patch}"
+
+
+def normalize_prerelease_channel(channel: str | None) -> str | None:
+    if channel is None:
+        return None
+    normalized = channel.strip().lower()
+    if not normalized:
+        return None
+    if not re.match(r"^[a-z][0-9a-z-]*$", normalized):
+        raise ValueError(f"Unsupported prerelease channel: {channel}")
+    return normalized
+
+
+def parse_prerelease_tag(tag: str) -> dict[str, Any] | None:
+    match = PRERELEASE_TAG_RE.match(tag)
+    if not match:
+        return None
+
+    major, minor, patch = match.groups()[:3]
+    channel = match.group("channel").lower()
+    number = int(match.group("number"))
+    return {
+        "tag": tag,
+        "baseTag": format_tag((int(major), int(minor), int(patch))),
+        "channel": channel,
+        "number": number,
+    }
 
 
 def strip_conventional(subject: str) -> tuple[str, str]:
@@ -287,6 +319,37 @@ def suggest_version(last_release: ReleaseInfo | None, meaningful_commits: list[d
     }
 
 
+def suggest_prerelease_version(repo_root: str, stable_tag: str, channel: str) -> dict[str, Any]:
+    pattern = f"{stable_tag}-{channel}.*"
+    tag_output = git("tag", "--list", pattern, cwd=repo_root)
+    existing_tags = [tag for tag in tag_output.splitlines() if tag.strip()]
+
+    matching_numbers: list[int] = []
+    for tag in existing_tags:
+        parsed = parse_prerelease_tag(tag)
+        if parsed and parsed["baseTag"] == stable_tag and parsed["channel"] == channel:
+            matching_numbers.append(parsed["number"])
+
+    next_number = max(matching_numbers, default=0) + 1
+    prerelease_tag = f"{stable_tag}-{channel}.{next_number}"
+    if matching_numbers:
+        reason = (
+            f"Existing {channel} prereleases for {stable_tag} already go up to "
+            f"`{stable_tag}-{channel}.{max(matching_numbers)}`, so increment to `{prerelease_tag}`."
+        )
+    else:
+        reason = f"No existing {channel} prereleases were found for {stable_tag}, so start at `{prerelease_tag}`."
+
+    return {
+        "tag": prerelease_tag,
+        "channel": channel,
+        "baseTag": stable_tag,
+        "number": next_number,
+        "existingTags": sorted(existing_tags),
+        "reason": reason,
+    }
+
+
 def build_release_items(repo_root: str, repo_name: str, commits: list[dict[str, Any]]) -> list[dict[str, Any]]:
     grouped: "OrderedDict[str, dict[str, Any]]" = OrderedDict()
     direct_count = 0
@@ -370,6 +433,13 @@ def render_markdown(plan: dict[str, Any]) -> str:
     lines.append(f"- Meaningful commits after filtering housekeeping: `{plan['counts']['meaningfulCommitCount']}`")
     lines.append(f"- Suggested tag: `{plan['suggestedVersion']['tag']}` ({plan['suggestedVersion']['kind']})")
     lines.append(f"- Version rationale: {plan['suggestedVersion']['reason']}")
+    prerelease_suggestion = plan.get("prereleaseSuggestion")
+    if prerelease_suggestion:
+        lines.append(
+            f"- Suggested prerelease tag: `{prerelease_suggestion['tag']}` "
+            f"({prerelease_suggestion['channel']}; based on `{prerelease_suggestion['baseTag']}`)"
+        )
+        lines.append(f"- Prerelease rationale: {prerelease_suggestion['reason']}")
     if plan["warnings"]:
         lines.append("")
         lines.append("## Warnings")
@@ -410,7 +480,8 @@ def render_markdown(plan: dict[str, Any]) -> str:
 
     lines.append("## Changelog Heading")
     lines.append("")
-    lines.append(f"Use this heading in `CHANGELOG.md`: `## {plan['suggestedVersion']['tag']} - {plan['generatedAtDate']}`")
+    heading_tag = prerelease_suggestion["tag"] if prerelease_suggestion else plan["suggestedVersion"]["tag"]
+    lines.append(f"Use this heading in `CHANGELOG.md`: `## {heading_tag} - {plan['generatedAtDate']}`")
     lines.append("")
     lines.append("Do not copy the raw titles verbatim into the release notes; rewrite them.")
     return "\n".join(lines).rstrip() + "\n"
@@ -461,6 +532,12 @@ def main() -> int:
 
     items = build_release_items(repo_root, repo_name, meaningful_commits)
     suggested_version = suggest_version(last_release, meaningful_commits)
+    prerelease_channel = normalize_prerelease_channel(args.prerelease_channel)
+    prerelease_suggestion = (
+        suggest_prerelease_version(repo_root, suggested_version["tag"], prerelease_channel)
+        if prerelease_channel
+        else None
+    )
 
     warnings: list[str] = []
     if not is_clean:
@@ -512,6 +589,7 @@ def main() -> int:
             "releaseItemCount": len(items),
         },
         "suggestedVersion": suggested_version,
+        "prereleaseSuggestion": prerelease_suggestion,
         "warnings": warnings,
         "ignoredCommits": ignored_commits,
         "rawCommits": raw_commits,
@@ -527,6 +605,8 @@ def main() -> int:
     print(f"Wrote {json_path}")
     print(f"Wrote {markdown_path}")
     print(f"Suggested tag: {suggested_version['tag']}")
+    if prerelease_suggestion is not None:
+        print(f"Suggested prerelease tag: {prerelease_suggestion['tag']}")
     print(f"Meaningful commits since last release: {len(meaningful_commits)}")
     return 0
 

--- a/.github/workflows/r_version.yml
+++ b/.github/workflows/r_version.yml
@@ -13,6 +13,15 @@ on:
       prSuffix:
         description: "Computed PR Suffix (e.g. '-pr-1' or '')"
         value: ${{ jobs.version.outputs.prSuffix }}
+      isPrerelease:
+        description: "Whether the release tag is a prerelease"
+        value: ${{ jobs.version.outputs.isPrerelease }}
+      releaseChannel:
+        description: "Release channel derived from the tag (e.g. 'beta' or 'stable')"
+        value: ${{ jobs.version.outputs.releaseChannel }}
+      npmDistTag:
+        description: "npm dist-tag derived from the release tag (e.g. 'beta' or 'latest')"
+        value: ${{ jobs.version.outputs.npmDistTag }}
 
 jobs:
   version:
@@ -20,6 +29,9 @@ jobs:
     outputs:
       prSuffix: ${{ steps.prSuffix.outputs.prSuffix }}
       packageVersion: ${{ steps.packageVersion.outputs.packageVersion }}
+      isPrerelease: ${{ steps.releaseMetadata.outputs.isPrerelease || 'false' }}
+      releaseChannel: ${{ steps.releaseMetadata.outputs.releaseChannel || 'stable' }}
+      npmDistTag: ${{ steps.releaseMetadata.outputs.npmDistTag || 'latest' }}
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
@@ -42,9 +54,9 @@ jobs:
             echo "PR_SUFFIX=" >> "$GITHUB_ENV"
           fi
 
-      - name: Extract release version from tag
+      - name: Extract release metadata from tag
         if: github.event_name == 'release'
-        id: releaseVersion
+        id: releaseMetadata
         run: node scripts/release-metadata.mjs "${{ github.ref_name }}"
 
       - name: Extract current package version
@@ -57,7 +69,7 @@ jobs:
       - name: Compute package version
         id: packageVersion
         run: |
-          BASE_VERSION="${{ steps.releaseVersion.outputs.version || steps.currentVersion.outputs.version }}"
+          BASE_VERSION="${{ steps.releaseMetadata.outputs.version || steps.currentVersion.outputs.version }}"
           if [ -n "${PR_NUMBER}" ]; then
             PACKAGE_VERSION="${BASE_VERSION}-pr.${PR_NUMBER}"
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,16 @@ jobs:
           echo "releaseChannel: ${{ needs.version.outputs.releaseChannel }}"
           echo "npmDistTag: ${{ needs.version.outputs.npmDistTag }}"
 
+      - name: Validate GitHub prerelease flag
+        env:
+          EXPECTED_PRERELEASE: ${{ needs.version.outputs.isPrerelease }}
+          ACTUAL_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          if [ "$EXPECTED_PRERELEASE" != "$ACTUAL_PRERELEASE" ]; then
+            echo "Release tag prerelease state ($EXPECTED_PRERELEASE) does not match GitHub release.prerelease ($ACTUAL_PRERELEASE)." >&2
+            exit 1
+          fi
+
       - name: Apply package version to the workspace
         run: node scripts/set-workspace-version.mjs "${{ needs.version.outputs.packageVersion }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
         run: |
           echo "packageVersion: ${{ needs.version.outputs.packageVersion }}"
           echo "prSuffix: ${{ needs.version.outputs.prSuffix }}"
+          echo "isPrerelease: ${{ needs.version.outputs.isPrerelease }}"
+          echo "releaseChannel: ${{ needs.version.outputs.releaseChannel }}"
+          echo "npmDistTag: ${{ needs.version.outputs.npmDistTag }}"
 
       - name: Apply package version to the workspace
         run: node scripts/set-workspace-version.mjs "${{ needs.version.outputs.packageVersion }}"
@@ -130,6 +133,7 @@ jobs:
         run: npx -p publib@latest publib-npm
         env:
           NPM_TOKEN: ${{ secrets.NPMJSORG_PUBLISH_TOKEN }}
+          NPM_DIST_TAG: ${{ needs.version.outputs.npmDistTag }}
 
     container:
       # 2023-01-04 release broke the build

--- a/scripts/release-metadata.mjs
+++ b/scripts/release-metadata.mjs
@@ -6,9 +6,9 @@ const metadata = parseReleaseTag(process.argv[2]);
 
 if (process.env.GITHUB_OUTPUT) {
   appendGitHubOutput('version', metadata.version);
-  appendGitHubOutput('is_prerelease', String(metadata.isPrerelease));
-  appendGitHubOutput('release_channel', metadata.channel ?? 'stable');
-  appendGitHubOutput('npm_dist_tag', metadata.npmDistTag);
+  appendGitHubOutput('isPrerelease', String(metadata.isPrerelease));
+  appendGitHubOutput('releaseChannel', metadata.channel ?? 'stable');
+  appendGitHubOutput('npmDistTag', metadata.npmDistTag);
 }
 
 process.stdout.write(`${JSON.stringify(metadata, null, 2)}\n`);

--- a/scripts/release-metadata.test.mjs
+++ b/scripts/release-metadata.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { spawnSync } from 'node:child_process';
+
+test('emits GitHub Action outputs for prerelease tags', () => {
+  const outputPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'release-metadata-')), 'github-output.txt');
+  const result = spawnSync('node', ['scripts/release-metadata.mjs', 'v0.0.0-beta.1'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: outputPath,
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+
+  const output = fs.readFileSync(outputPath, 'utf8');
+  assert.match(output, /^version=0\.0\.0-beta\.1$/m);
+  assert.match(output, /^isPrerelease=true$/m);
+  assert.match(output, /^releaseChannel=beta$/m);
+  assert.match(output, /^npmDistTag=beta$/m);
+});

--- a/tests/workflows/node22-release-smoke.test.mjs
+++ b/tests/workflows/node22-release-smoke.test.mjs
@@ -55,6 +55,20 @@ test('direct setup-node usage disables package-manager auto-cache', () => {
   }
 });
 
+test('release workflows propagate prerelease metadata through to npm publishing', () => {
+  const versionWorkflow = fs.readFileSync(path.join(repoRoot, '.github', 'workflows', 'r_version.yml'), 'utf8');
+  const releaseWorkflow = fs.readFileSync(path.join(repoRoot, '.github', 'workflows', 'release.yml'), 'utf8');
+
+  assert.match(versionWorkflow, /isPrerelease:/);
+  assert.match(versionWorkflow, /releaseChannel:/);
+  assert.match(versionWorkflow, /npmDistTag:/);
+  assert.match(versionWorkflow, /id:\s+releaseMetadata/);
+  assert.match(versionWorkflow, /value:\s+\$\{\{\s*jobs\.version\.outputs\.npmDistTag\s*\}\}/);
+
+  assert.match(releaseWorkflow, /echo "npmDistTag: \$\{\{\s*needs\.version\.outputs\.npmDistTag\s*\}\}"/);
+  assert.match(releaseWorkflow, /NPM_DIST_TAG:\s+\$\{\{\s*needs\.version\.outputs\.npmDistTag\s*\}\}/);
+});
+
 test('the construct runtime baseline is nodejs22.x', () => {
   const source = fs.readFileSync(
     path.join(repoRoot, 'packages', 'cdk-construct', 'src', 'index.ts'),

--- a/tests/workflows/node22-release-smoke.test.mjs
+++ b/tests/workflows/node22-release-smoke.test.mjs
@@ -66,6 +66,9 @@ test('release workflows propagate prerelease metadata through to npm publishing'
   assert.match(versionWorkflow, /value:\s+\$\{\{\s*jobs\.version\.outputs\.npmDistTag\s*\}\}/);
 
   assert.match(releaseWorkflow, /echo "npmDistTag: \$\{\{\s*needs\.version\.outputs\.npmDistTag\s*\}\}"/);
+  assert.match(releaseWorkflow, /Validate GitHub prerelease flag/);
+  assert.match(releaseWorkflow, /EXPECTED_PRERELEASE:\s+\$\{\{\s*needs\.version\.outputs\.isPrerelease\s*\}\}/);
+  assert.match(releaseWorkflow, /ACTUAL_PRERELEASE:\s+\$\{\{\s*github\.event\.release\.prerelease\s*\}\}/);
   assert.match(releaseWorkflow, /NPM_DIST_TAG:\s+\$\{\{\s*needs\.version\.outputs\.npmDistTag\s*\}\}/);
 });
 


### PR DESCRIPTION
## Summary

I tightened the beta release workflow so the GitHub release metadata has to agree with the release tag.

- I validate that a prerelease tag like `v0.0.0-beta.1` is paired with `github.event.release.prerelease=true`.
- I kept the npm beta dist-tag wiring and extended the workflow smoke test to cover the new guardrail.

## Verification

I verified the release helper tests pass:

```bash
node --test scripts/release-tag.test.mjs scripts/release-metadata.test.mjs tests/workflows/node22-release-smoke.test.mjs
```

I also verified the release planner can deterministically suggest the next beta tag:

```bash
python3 .agents/skills/release/scripts/release_plan.py --output-dir .local/release-smoke --prerelease-channel beta
```
